### PR TITLE
Allow labels to be hidden

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -40,6 +40,7 @@ const OSDInterface = new Lang.Class({
     /** @param double maxLevel */
     showOSD: function (iconName, label, level, maxLevel) {
         let gicon = Gio.icon_new_for_string(iconName);
+        if ( label === '' ) label = undefined;
         // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/osdWindow.js#L174
         Main.osdWindowManager.show(-1, gicon, label, level, maxLevel);
     }


### PR DESCRIPTION
Setting label to empty string should make it undefined by default - this will hide label from OSD and make it looking better.
https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/osdWindow.js#L65